### PR TITLE
Remove pppd option 'nomp'

### DIFF
--- a/nxbender/ppp.py
+++ b/nxbender/ppp.py
@@ -29,7 +29,6 @@ class PPPSession(object):
                 'noipdefault',
                 'noccp',    # server is buggy
                 'noauth',
-                'nomp',
                 'usepeerdns',
         ]
 


### PR DESCRIPTION
On Fedora 39, `pppd` does not recognize option `nomp`.

Example output from `journalctl -xe` after running `nxBender` with package `ppp-2.5.0-3.fc39.x86_64` installed:

> Mar 27 16:08:22 fedora pppd[5845]: unrecognized option 'nomp'

Also note that package `NetExtender-10.2.845-1.x86_64` installs `/etc/ppp/peers/sslvpn`, which comments out `nomp` like so:

```
#Multi-link disabled in pppd
#nomp
```